### PR TITLE
Automatically create submodule redirect required for projects to reference the editor API

### DIFF
--- a/Build/Projects/Protogame.Editor.Ext.CodeManager.definition
+++ b/Build/Projects/Protogame.Editor.Ext.CodeManager.definition
@@ -13,6 +13,7 @@
     <DebugSymbolsOnRelease>full</DebugSymbolsOnRelease>
   </Properties>
   <Files>
+    <Compile Include="ApiReferenceService.cs" />
     <Compile Include="CodeManagerEditorExtension.cs" />
     <Compile Include="CodeManagerMenuProvider.cs" />
     <Compile Include="CodeManagerService.cs" />

--- a/Protogame.Editor.Ext.CodeManager/ApiReferenceService.cs
+++ b/Protogame.Editor.Ext.CodeManager/ApiReferenceService.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Protogame.Editor.Api.Version1.ProjectManagement;
+using System.IO;
+using Protogame.Editor.Api.Version1;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+
+namespace Protogame.Editor.Ext.CodeManager
+{
+    public class ApiReferenceService : IApiReferenceService
+    {
+        private readonly IProjectManager _projectManager;
+        private string _lastDirectory;
+
+        public ApiReferenceService(IProjectManager projectManager)
+        {
+            _projectManager = projectManager;
+        }
+
+        public void Update()
+        {
+            if (_projectManager.Project != null)
+            {
+                var directory = Path.Combine(_projectManager.Project.ProjectPath.FullName, "Protogame.Editor");
+                if (directory != _lastDirectory)
+                {
+                    ForceCheck();
+                }
+            }
+        }
+
+        public void ForceCheck()
+        {
+            var directory = Path.Combine(_projectManager.Project.ProjectPath.FullName, "Protogame.Editor");
+            var redirect = Path.Combine(directory, ".redirect");
+
+            Directory.CreateDirectory(directory);
+            using (var writer = new StreamWriter(redirect, false))
+            {
+                writer.Write(GetBuildReferencesFolder());
+            }
+
+            _lastDirectory = directory;
+        }
+
+        private string GetBuildReferencesFolder()
+        {
+            var apiReferencePath = typeof(ExtensionAttribute).Assembly.Location;
+            string tempDirName;
+            using (var sha = SHA1.Create())
+            {
+                tempDirName = "PGEditorReferences_v1_" + BitConverter.ToString(sha.ComputeHash(Encoding.ASCII.GetBytes(apiReferencePath))).Replace("-", "");
+            }
+            tempDirName = Path.Combine(Path.GetTempPath(), tempDirName);
+
+            if (Directory.Exists(tempDirName))
+            {
+                return tempDirName;
+            }
+
+            Directory.CreateDirectory(tempDirName);
+            Directory.CreateDirectory(Path.Combine(tempDirName, "Build", "Projects"));
+            
+            var document = new XmlDocument();
+            document.AppendChild(document.CreateXmlDeclaration("1.0", "utf-8", null));
+
+            var module = document.CreateElement("Module");
+            var nameNode = document.CreateElement("Name");
+            nameNode.InnerText = "Protogame.Editor.References";
+            module.AppendChild(nameNode);
+            document.AppendChild(module);
+
+            document.Save(Path.Combine(tempDirName, "Build", "Module.xml"));
+
+            document = new XmlDocument();
+
+            document.AppendChild(document.CreateXmlDeclaration("1.0", "utf-8", null));
+
+            var externalProject = document.CreateElement("ExternalProject");
+            externalProject.SetAttribute("Name", "Protogame.Editor.Api");
+            var binaryNode = document.CreateElement("Binary");
+            binaryNode.SetAttribute("Name", "Protogame.Editor.Api");
+            binaryNode.SetAttribute("Path", apiReferencePath);
+            externalProject.AppendChild(binaryNode);
+            document.AppendChild(externalProject);
+
+            document.Save(Path.Combine(tempDirName, "Build", "Projects", "Protogame.Editor.Api.definition"));
+
+            File.Copy(Path.Combine(_projectManager.Project.ProjectPath.FullName, "Protobuild.exe"), Path.Combine(tempDirName, "Protobuild.exe"), true);
+
+            return tempDirName;
+        }
+    }
+
+    public interface IApiReferenceService
+    {
+        void Update();
+
+        void ForceCheck();
+    }
+}

--- a/Protogame.Editor.Ext.CodeManager/CodeManagerEditorExtension.cs
+++ b/Protogame.Editor.Ext.CodeManager/CodeManagerEditorExtension.cs
@@ -17,6 +17,7 @@ namespace Protogame.Editor.Ext.CodeManager
             kernel.Bind<IToolbarProvider>().To<CodeManagerToolbarProvider>().InSingletonScope();
             kernel.Bind<IWantsUpdateSignal>().To<CodeManagerUpdateSignal>().InSingletonScope();
             kernel.Bind<ICodeManagerService>().To<CodeManagerService>().InSingletonScope();
+            kernel.Bind<IApiReferenceService>().To<ApiReferenceService>().InSingletonScope();
         }
     }
 }

--- a/Protogame.Editor.Ext.CodeManager/CodeManagerService.cs
+++ b/Protogame.Editor.Ext.CodeManager/CodeManagerService.cs
@@ -13,13 +13,16 @@ namespace Protogame.Editor.Ext.CodeManager
         private readonly IConsoleHandle _consoleHandle;
         private IProject _project;
         private Process _process;
+        private readonly IApiReferenceService _apiReferenceService;
 
         public CodeManagerService(
             IProjectManager projectManager,
-            IConsoleHandle consoleHandle)
+            IConsoleHandle consoleHandle,
+            IApiReferenceService apiReferenceService)
         {
             _projectManager = projectManager;
             _consoleHandle = consoleHandle;
+            _apiReferenceService = apiReferenceService;
         }
 
         public bool IsProcessRunning => _process != null;
@@ -64,6 +67,7 @@ namespace Protogame.Editor.Ext.CodeManager
                 return;
             }
 
+            _apiReferenceService.ForceCheck();
             StartProtobuild("--resync", null);
         }
 
@@ -74,6 +78,7 @@ namespace Protogame.Editor.Ext.CodeManager
                 return;
             }
 
+            _apiReferenceService.ForceCheck();
             StartProtobuild("--sync", null);
         }
 
@@ -84,6 +89,7 @@ namespace Protogame.Editor.Ext.CodeManager
                 return;
             }
 
+            _apiReferenceService.ForceCheck();
             StartProtobuild("--generate", null);
         }
 
@@ -94,6 +100,7 @@ namespace Protogame.Editor.Ext.CodeManager
                 return;
             }
 
+            _apiReferenceService.ForceCheck();
             StartProtobuild("--upgrade-all", null);
         }
 

--- a/Protogame.Editor.Ext.CodeManager/CodeManagerUpdateSignal.cs
+++ b/Protogame.Editor.Ext.CodeManager/CodeManagerUpdateSignal.cs
@@ -4,15 +4,20 @@ namespace Protogame.Editor.Ext.CodeManager
 {
     public class CodeManagerUpdateSignal : IWantsUpdateSignal
     {
-        private ICodeManagerService _codeManagerService;
+        private readonly IApiReferenceService _apiReferenceService;
+        private readonly ICodeManagerService _codeManagerService;
 
-        public CodeManagerUpdateSignal(ICodeManagerService codeManagerService)
+        public CodeManagerUpdateSignal(
+            IApiReferenceService apiReferenceService,
+            ICodeManagerService codeManagerService)
         {
+            _apiReferenceService = apiReferenceService;
             _codeManagerService = codeManagerService;
         }
 
         public void Update()
         {
+            _apiReferenceService.Update();
             _codeManagerService.Update();
         }
     }

--- a/Protogame.Editor/EditorWindow/ExtensionManagerEditorWindow.cs
+++ b/Protogame.Editor/EditorWindow/ExtensionManagerEditorWindow.cs
@@ -50,20 +50,24 @@ namespace Protogame.Editor.EditorWindow
                 {
                     Text = "Debug"
                 };
-                var disableButton = new Button
+                var restartButton = new Button
                 {
-                    Text = "Disable",
-                    Enabled = false
+                    Text = "Restart"
                 };
 
                 debugButton.Click += (sender, e) =>
                 {
                     _extensionManager.DebugExtension(ext);
                 };
+                restartButton.Click += (sender, e) =>
+                {
+                    _extensionManager.RestartExtension(ext);
+                };
+
 
                 var buttonContainer = new VerticalContainer();
                 buttonContainer.AddChild(debugButton, "24");
-                buttonContainer.AddChild(disableButton, "24");
+                buttonContainer.AddChild(restartButton, "24");
 
                 var horizontalContainer = new HorizontalContainer();
                 horizontalContainer.Userdata = ext;

--- a/Protogame.Editor/Extension/ExtensionManager.cs
+++ b/Protogame.Editor/Extension/ExtensionManager.cs
@@ -47,6 +47,17 @@ namespace Protogame.Editor.Extension
             managedExtension.ShouldRestart = true;
         }
 
+        public void RestartExtension(Extension extension)
+        {
+            if (!_extensions.ContainsKey(extension.Path))
+            {
+                return;
+            }
+
+            var managedExtension = _extensions[extension.Path];
+            managedExtension.ShouldRestart = true;
+        }
+
         public void Update()
         {
             if (!_hasLoadedBundledExtensions)

--- a/Protogame.Editor/Extension/IExtensionManager.cs
+++ b/Protogame.Editor/Extension/IExtensionManager.cs
@@ -7,5 +7,7 @@
         void Update();
 
         void DebugExtension(Extension extension);
+
+        void RestartExtension(Extension extension);
     }
 }


### PR DESCRIPTION
This makes the code manager automatically generate both a temporary submodule and create the redirect to it, so that projects can reference the editor API.